### PR TITLE
Innlogging uten hash

### DIFF
--- a/kartverketprosjekt/Controllers/BrukerController.cs
+++ b/kartverketprosjekt/Controllers/BrukerController.cs
@@ -26,9 +26,23 @@ public class BrukerController : Controller
         if (user != null)
         {
             var passwordHasher = new PasswordHasher<BrukerModel>();
-            var result = passwordHasher.VerifyHashedPassword(user, user.passord, password);
 
-            if (result == PasswordVerificationResult.Success)
+            // Check if the password in the database is hashed or not
+            bool isPasswordValid;
+
+            if (IsHashedPassword(user.passord))
+            {
+                // Verify hashed password
+                var result = passwordHasher.VerifyHashedPassword(user, user.passord, password);
+                isPasswordValid = result == PasswordVerificationResult.Success;
+            }
+            else
+            {
+                // Compare plaintext password
+                isPasswordValid = user.passord == password;
+            }
+
+            if (isPasswordValid)
             {
                 // Create claims for the logged-in user
                 var claims = new List<Claim>
@@ -48,6 +62,13 @@ public class BrukerController : Controller
         ViewBag.ErrorMessage = "Invalid login attempt";
         return View("Index");
     }
+
+    private bool IsHashedPassword(string password)
+    {
+        // Example: Assume that a hashed password is at least 60 characters (bcrypt or similar)
+        return password.Length >= 60;
+    }
+
     // POST logout
     [HttpPost]
     public async Task<IActionResult> Logout()


### PR DESCRIPTION
Fikset innlogging uten hash med en metode som prøver hash, og hvis ikke det er hash så prøver den normalt passord før den kaster error.