### PR TITLE
db i http fix

### DIFF
--- a/kartverketprosjekt/docker-compose.yml
+++ b/kartverketprosjekt/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       MYSQL_DATABASE: kartverketdb
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - "3307:3306"  # Map port 3306 in the container to port 3307 on your host
     networks:
       - kartverket-network
 


### PR DESCRIPTION
Når du sitter å jobber og ønsker å kjøre programmet i http så endrer du denne:
`"DefaultConnection": "Server=db;Port=3306;Database=kartverketdb;User Id=root;Password=root;"`
til
`"DefaultConnection": "Server=localhost;Port=3307;Database=kartverketdb;User Id=root;Password=root;"`

Husk å builde db.contaieneren på nytt med `docker-compose down` -> `docker volume prune` -> `docker-compose up --build`