### PR TITLE
Add priority handling for cases based on user access level

### DIFF
--- a/kartverketprosjekt/Controllers/SakController.cs
+++ b/kartverketprosjekt/Controllers/SakController.cs
@@ -36,6 +36,18 @@ namespace kartverketprosjekt.Controllers
         {
             // Hent e-post fra den innloggede brukeren
             sak.epost_bruker = User.Identity.Name;
+            
+            // Hent brukerens tilgangsnivå fra databasen
+            var bruker = await _context.Bruker
+                .FirstOrDefaultAsync(b => b.epost == sak.epost_bruker);
+            if (bruker == null)
+            {
+                // Hvis brukeren ikke finnes, returner en feil
+                return BadRequest("Innlogget bruker ble ikke funnet.");
+            }
+
+            // Sjekk om brukeren har en prioritert tilgangsnivå (f.eks. 2 for Prioritert Bruker)
+            sak.IsPriority = bruker.tilgangsnivaa_id == 2;
 
             // Hardkodede verdier for kommune_id og status
             sak.kommune_id = 1;

--- a/kartverketprosjekt/Models/SakModel.cs
+++ b/kartverketprosjekt/Models/SakModel.cs
@@ -24,6 +24,9 @@ namespace kartverketprosjekt.Models
         public ICollection<KommentarModel> Kommentarer { get; set; } = new List<KommentarModel>();
 
         public bool status_endret { get; set; } = false;
+
+        // Nytt felt for å indikere om saken er prioritert
+        public bool IsPriority { get; set; } = false;
     }
 }
 

--- a/kartverketprosjekt/Views/Saksbehandler/CaseWorkerView.cshtml
+++ b/kartverketprosjekt/Views/Saksbehandler/CaseWorkerView.cshtml
@@ -54,7 +54,7 @@
 
             @foreach (var sak in ViewBag.Saker)
             {
-                <tr data-sakid='@sak.id' data-geojson='@Html.Raw(Json.Serialize(sak.geojson_data))' data-layerurl='@sak.layerurl' data-beskrivelse='@sak.beskrivelse' data-vedlegg='@sak.vedlegg'>
+                <tr class="@(sak.IsPriority ? "priority-row":"")" data-sakid='@sak.id' data-geojson='@Html.Raw(Json.Serialize(sak.geojson_data))' data-layerurl='@sak.layerurl' data-beskrivelse='@sak.beskrivelse' data-vedlegg='@sak.vedlegg'>
                     <td>@(sak.epost_bruker ?? "ikke registrert")</td>
                     <td>@sak.type_feil</td>
                     <td>@(sak.vedlegg != null ? "Ja" : "Nei")</td>

--- a/kartverketprosjekt/init.sql
+++ b/kartverketprosjekt/init.sql
@@ -40,6 +40,7 @@ CREATE TABLE Sak (
     Kommunenummer VARCHAR(50),      -- Kan være en string, avhengig av hvordan nummeret lagres
     Fylkesnavn VARCHAR(255),
     Fylkesnummer VARCHAR(50),
+    IsPriority BOOLEAN DEFAULT FALSE, -- Nytt felt for å indikere om saken er prioritert
     FOREIGN KEY (epost_bruker) REFERENCES Bruker(epost),
     FOREIGN KEY (kommune_id) REFERENCES Kommune(id) -- Relasjon til Kommune-tabellen
 );

--- a/kartverketprosjekt/wwwroot/css/site.css
+++ b/kartverketprosjekt/wwwroot/css/site.css
@@ -504,9 +504,13 @@ form input[type="file"] {
 .hidden-form {
     all: unset;
 }
+.priority-row {
+    color: #ff6961; /* Warm red*/
+    font-weight: bold; /* Bold text for emphasis */
+}
 
-/* Style for the select element */
-select.form-control {
+    /* Style for the select element */
+    select.form-control {
     width: 100%;
     padding: 0.5rem;
     background-color: var(--form-background-color);


### PR DESCRIPTION
- Fetch user's access level in SakController.cs and set IsPriority in SakModel.
- Introduce IsPriority property in SakModel.cs.
- Update CaseWorkerView.cshtml to add priority-row class for prioritized cases.
- Modify init.sql to add IsPriority column to Sak table.
- Add CSS styles in site.css to highlight prioritized rows.