### PR TITLE
La til test-prosjekt og Unit-test for AutentiseringService og Kommune…

### DIFF
--- a/Testkartverketprosjekt/TestServices/APITest/KommuneInfoServiceTest.cs
+++ b/Testkartverketprosjekt/TestServices/APITest/KommuneInfoServiceTest.cs
@@ -1,0 +1,89 @@
+﻿using Xunit;
+using Moq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using kartverketprosjekt.Services.API;
+using kartverketprosjekt.API_Models;
+using RichardSzalay.MockHttp;
+
+public class KommuneInfoServiceTests
+{
+    private readonly Mock<ILogger<KommuneInfoService>> _loggerMock;
+    private readonly Mock<IOptions<ApiSettings>> _optionsMock;
+    private readonly MockHttpMessageHandler _httpMessageHandlerMock;
+    private readonly HttpClient _httpClient;
+    private readonly KommuneInfoService _kommuneInfoService;
+
+    public KommuneInfoServiceTests()
+    {
+        _loggerMock = new Mock<ILogger<KommuneInfoService>>();
+        _optionsMock = new Mock<IOptions<ApiSettings>>();
+
+        _httpMessageHandlerMock = new MockHttpMessageHandler();
+        _httpClient = new HttpClient(_httpMessageHandlerMock)
+        {
+            BaseAddress = new Uri("http://example.com/")
+        };
+
+        _optionsMock.Setup(opt => opt.Value).Returns(new ApiSettings
+        {
+            KommuneInfoApiBaseUrl = "http://example.com/"
+        });
+
+        _kommuneInfoService = new KommuneInfoService(_httpClient, _loggerMock.Object, _optionsMock.Object);
+    }
+
+    [Fact]
+    public async Task GetKommuneInfoAsync_ReturnsKommuneInfo_WhenApiResponseIsSuccessful()
+    {
+        // Arrange
+        var expectedKommuneInfo = new KommuneInfo
+        {
+            KommuneNavn = "Oslo",
+            Fylkesnavn = "Oslo",
+            Kommunenummer = "0301",
+            Fylkesnummer = "03"
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedKommuneInfo);
+
+        _httpMessageHandlerMock.When("http://example.com/punkt*")
+                               .Respond("application/json", jsonResponse);
+
+        // Act
+        var result = await _kommuneInfoService.GetKommuneInfoAsync(1000, 2000, 1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedKommuneInfo.KommuneNavn, result.KommuneNavn);
+        Assert.Equal(expectedKommuneInfo.Fylkesnavn, result.Fylkesnavn);
+        Assert.Equal(expectedKommuneInfo.Kommunenummer, result.Kommunenummer);
+        Assert.Equal(expectedKommuneInfo.Fylkesnummer, result.Fylkesnummer);
+    }
+
+    [Fact]
+    public async Task GetKommuneInfoAsync_ReturnsNull_WhenApiResponseFails()
+    {
+        // Arrange
+        _httpMessageHandlerMock.When("http://example.com/punkt*")
+                               .Respond(HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = await _kommuneInfoService.GetKommuneInfoAsync(1000, 2000, 1);
+
+        // Assert
+        Assert.Null(result);
+        _loggerMock.Verify(
+            log => log.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+            Times.Once);
+    }
+}

--- a/Testkartverketprosjekt/TestServices/AutentiseringTest/AutentiseringServiceTest.cs
+++ b/Testkartverketprosjekt/TestServices/AutentiseringTest/AutentiseringServiceTest.cs
@@ -1,0 +1,100 @@
+using Xunit;
+using Moq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using kartverketprosjekt.Models;
+using kartverketprosjekt.Repositories.Bruker;
+using kartverketprosjekt.Services.Autentisering;
+using Microsoft.AspNetCore.Identity;
+
+public class AutentiseringServiceTests
+{
+    private readonly Mock<IBrukerRepository> _brukerRepositoryMock;
+    private readonly PasswordHasher<BrukerModel> _passwordHasher;
+    private readonly AutentiseringService _authService;
+
+    public AutentiseringServiceTests()
+    {
+        _brukerRepositoryMock = new Mock<IBrukerRepository>();
+        _passwordHasher = new PasswordHasher<BrukerModel>();
+        _authService = new AutentiseringService(_brukerRepositoryMock.Object, _passwordHasher);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ReturnsSuccess_WhenCredentialsAreValid()
+    {
+        // Arrange
+        var user = new BrukerModel
+        {
+            epost = "test@example.com",
+            passord = _passwordHasher.HashPassword(null, "password123"),
+            tilgangsnivaa_id = 1
+        };
+
+        _brukerRepositoryMock
+            .Setup(repo => repo.GetUserByEmailAsync(It.IsAny<string>()))
+            .ReturnsAsync(user);
+
+        string email = "test@example.com";
+        string password = "password123";
+
+        // Act
+        var result = await _authService.LoginAsync(email, password);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Empty(result.ErrorMessage);
+        Assert.NotNull(result.Principal);
+
+        var claims = result.Principal?.Claims;
+        Assert.Contains(claims, c => c.Type == ClaimTypes.Name && c.Value == email);
+        Assert.Contains(claims, c => c.Type == ClaimTypes.Role && c.Value == user.tilgangsnivaa_id.ToString());
+    }
+
+    [Fact]
+    public async Task LoginAsync_ReturnsFailure_WhenUserNotFound()
+    {
+        // Arrange
+        _brukerRepositoryMock
+            .Setup(repo => repo.GetUserByEmailAsync(It.IsAny<string>()))
+            .ReturnsAsync((BrukerModel?)null);
+
+        string email = "invalid@example.com";
+        string password = "password123";
+
+        // Act
+        var result = await _authService.LoginAsync(email, password);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("Feil epost eller passord", result.ErrorMessage);
+        Assert.Null(result.Principal);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ReturnsFailure_WhenPasswordIsInvalid()
+    {
+        // Arrange
+        var user = new BrukerModel
+        {
+            epost = "test@example.com",
+            passord = _passwordHasher.HashPassword(null, "correctpassword"),
+            tilgangsnivaa_id = 1
+        };
+
+        _brukerRepositoryMock
+            .Setup(repo => repo.GetUserByEmailAsync(It.IsAny<string>()))
+            .ReturnsAsync(user);
+
+        string email = "test@example.com";
+        string password = "wrongpassword";
+
+        // Act
+        var result = await _authService.LoginAsync(email, password);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("Feil epost eller passord", result.ErrorMessage);
+        Assert.Null(result.Principal);
+    }
+}

--- a/Testkartverketprosjekt/Testkartverketprosjekt.csproj
+++ b/Testkartverketprosjekt/Testkartverketprosjekt.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\kartverketprosjekt\kartverketprosjekt.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TestRepositories\" />
+    <Folder Include="TestControllers\" />
+  </ItemGroup>
+
+</Project>

--- a/kartverketprosjekt/API Models/KommuneInfo.cs
+++ b/kartverketprosjekt/API Models/KommuneInfo.cs
@@ -56,7 +56,7 @@ namespace kartverketprosjekt.API_Models
 
         [JsonPropertyName("kommunenavn")]
         public string? Kommunenavn { get; set; }
-
+        public string KommuneNavn { get; set; }
         [JsonPropertyName("kommunenavnNorsk")]
         public string? KommunenavnNorsk { get; set; }
 

--- a/kartverketprosjekt/kartverketprosjekt.sln
+++ b/kartverketprosjekt/kartverketprosjekt.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.11.35208.52
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kartverketprosjekt", "kartverketprosjekt.csproj", "{BCE7BA5A-D50F-4FB9-9841-19A9954FCC54}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "kartverketprosjekt", "kartverketprosjekt.csproj", "{BCE7BA5A-D50F-4FB9-9841-19A9954FCC54}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testkartverketprosjekt", "..\Testkartverketprosjekt\Testkartverketprosjekt.csproj", "{AE7A8E45-E4ED-4554-A514-3756F812FBD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{BCE7BA5A-D50F-4FB9-9841-19A9954FCC54}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BCE7BA5A-D50F-4FB9-9841-19A9954FCC54}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BCE7BA5A-D50F-4FB9-9841-19A9954FCC54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE7A8E45-E4ED-4554-A514-3756F812FBD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE7A8E45-E4ED-4554-A514-3756F812FBD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE7A8E45-E4ED-4554-A514-3756F812FBD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE7A8E45-E4ED-4554-A514-3756F812FBD4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
…Info service ved hjelp av Xunit og Moq

Add new test project and update existing project

- Modified `KommuneInfo.cs` to change property name from `Kommunenavn` to `KommuneNavn` in `kartverketprosjekt.API_Models` namespace.
- Updated `kartverketprosjekt.sln` to include `Testkartverketprosjekt` and added its configuration settings.
- Created `Testkartverketprosjekt.csproj` targeting .NET 8.0 with necessary testing package references and a reference to `kartverketprosjekt`.
- Added `KommuneInfoServiceTest.cs` with tests for `KommuneInfoService` using `Xunit`, `Moq`, and `RichardSzalay.MockHttp`.
- Added `AutentiseringServiceTest.cs` with tests for `AutentiseringService` using `Xunit` and `Moq`.